### PR TITLE
improvements

### DIFF
--- a/WatsonWebsocket/ClientMetadata.cs
+++ b/WatsonWebsocket/ClientMetadata.cs
@@ -15,6 +15,7 @@ namespace WatsonWebsocket
         public WebSocket Ws;
         public WebSocketContext WsContext;
         public readonly SemaphoreSlim SendAsyncLock = new SemaphoreSlim(1);
+        public readonly CancellationTokenSource KillToken = new CancellationTokenSource();
 
         #endregion
 

--- a/WatsonWebsocket/WatsonWsClient.cs
+++ b/WatsonWebsocket/WatsonWsClient.cs
@@ -1,14 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.WebSockets;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -402,18 +396,13 @@ namespace WatsonWebsocket
 
                 #region Format-Message
 
-                string header = "";
-                byte[] headerBytes;
-                byte[] message;
+                string header = (data == null || data.Length < 1) ? "0:" : data.Length + ":";
 
-                if (data == null || data.Length < 1) header += "0:";
-                else header += data.Length + ":";
-
-                headerBytes = Encoding.UTF8.GetBytes(header);
+                var headerBytes = Encoding.UTF8.GetBytes(header);
                 int messageLen = headerBytes.Length;
                 if (data != null && data.Length > 0) messageLen += data.Length;
 
-                message = new byte[messageLen];
+                var message = new byte[messageLen];
                 Buffer.BlockCopy(headerBytes, 0, message, 0, headerBytes.Length);
 
                 if (data != null && data.Length > 0) Buffer.BlockCopy(data, 0, message, headerBytes.Length, data.Length);

--- a/WatsonWebsocket/WatsonWsServer.cs
+++ b/WatsonWebsocket/WatsonWsServer.cs
@@ -449,7 +449,7 @@ namespace WatsonWebsocket
                 try
                 {
                     await client.Ws.SendAsync(new ArraySegment<byte>(data, 0, data.Length),
-                        WebSocketMessageType.Binary, true, CancellationToken.None);
+                        WebSocketMessageType.Text, true, CancellationToken.None);
                 }
                 finally
                 {


### PR DESCRIPTION
1. when sending a message optionally specify text or binary (default)
Text is best for web clients (e.g. json messages), binary for others

2. Clean up async tasks and cancellation tokens - disconnect task wasn't being started so made it synchronous

3. allow server to kick a client
Needed this to handle physical layer disconnect (e.g. network cable pulled) - our protocol has a ping message and both client and server can timeout the connection - needed to be able to tell the server to kick a client that hadn't been pinging. Did this by cancelling the token that ReadAsync and WriteAsync use. There's now a token per client in the metadata object.