### PR TITLE
Continue running the server when client is bad

### DIFF
--- a/WatsonWebsocket/WatsonWsClient.cs
+++ b/WatsonWebsocket/WatsonWsClient.cs
@@ -89,6 +89,10 @@ namespace WatsonWebsocket
             MaxEmptyMessages = 10;
 
             if (acceptInvalidCerts) ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => true;
+
+            TokenSource = new CancellationTokenSource();
+            Token = TokenSource.Token;
+
             ClientWs = new ClientWebSocket();
             ClientWs.ConnectAsync(ServerUri, CancellationToken.None)
                 .ContinueWith(AfterConnect);
@@ -113,9 +117,7 @@ namespace WatsonWebsocket
         {
             ServerUri = uri;
             ServerConnected = serverConnected ?? null;
-
             ServerDisconnected = serverDisconnected ?? null;
-
             Debug = debug;
             MessageReceived = messageReceived ?? throw new ArgumentNullException(nameof(messageReceived));
             SendLock = new SemaphoreSlim(1);
@@ -141,7 +143,7 @@ namespace WatsonWebsocket
         {
             Dispose(true);
         }
-         
+
         /// <summary>
         /// Send data to the server asynchronously
         /// </summary>

--- a/WatsonWebsocket/WatsonWsServer.cs
+++ b/WatsonWebsocket/WatsonWsServer.cs
@@ -65,10 +65,8 @@ namespace WatsonWebsocket
         {
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
 
-            ClientConnected = clientConnected ?? null;
-
-            ClientDisconnected = clientDisconnected ?? null;
-
+            ClientConnected = clientConnected;
+            ClientDisconnected = clientDisconnected;
             PermittedIps = null;
 
             MessageReceived = messageReceived ?? throw new ArgumentNullException(nameof(MessageReceived));
@@ -268,7 +266,7 @@ namespace WatsonWebsocket
                                 Log("*** AcceptConnections rejecting connection from " + clientIp + " (not permitted)");
                                 httpContext.Response.StatusCode = 401;
                                 httpContext.Response.Close();
-                                return;
+                                continue;
                             }
                         }
 
@@ -288,7 +286,7 @@ namespace WatsonWebsocket
                             Log("*** AcceptConnections unable to retrieve websocket content for client " + clientIp + ":" + clientPort);
                             httpContext.Response.StatusCode = 500;
                             httpContext.Response.Close();
-                            return;
+                            continue;
                         }
 
                         WebSocket ws = wsContext.WebSocket;


### PR DESCRIPTION
I noticed that the server stops running if the client isn't able to properly connect (either because it's bad or because the ip address isn't allowed).  This is likely undesirable behavior.

While I was running this test I also saw that the token properties weren't being set properly on the `WatsonWsServer` constructor that takes the ip/port so I included those as well.