### PR TITLE
Ensure socket is closed on a client disconnect

### DIFF
--- a/WatsonWebsocket/WatsonWsServer.cs
+++ b/WatsonWebsocket/WatsonWsServer.cs
@@ -390,6 +390,7 @@ namespace WatsonWebsocket
                     // must only fire disconnected event if the client was previously connected. Note that
                     // multithreading gives multiple disconnection events from the socket, the reader and the writer
                     ClientDisconnected?.Invoke(clientId);
+                    client.Ws.Dispose();
                     Log("DataReceiver client " + clientId + " disconnected (now " + Clients.Count + " clients active)");
                 }
             }


### PR DESCRIPTION
I was using https://www.websocket.org/echo.html for testing and saw that clicking `disconnect` didn't fully disconnect the client.