### PR TITLE
Reducing memory allocations for receiving data

### DIFF
--- a/src/Test.Client/Program.cs
+++ b/src/Test.Client/Program.cs
@@ -91,10 +91,10 @@ namespace Test.Client
                         Console.Write("Data: ");
                         userInput = Console.ReadLine();
                         if (String.IsNullOrEmpty(userInput)) break;
-                        byte[] resultBytes = _Client.SendAndWaitAsync(Encoding.UTF8.GetBytes(userInput)).Result;
-                        if (resultBytes != null && resultBytes.Length > 0)
+                        var resultBytes = _Client.SendAndWaitAsync(Encoding.UTF8.GetBytes(userInput)).Result;
+                        if (resultBytes != null && resultBytes.Count > 0)
                         {
-                            Console.WriteLine("Response: " + Encoding.UTF8.GetString(resultBytes));
+                            Console.WriteLine("Response: " + Encoding.UTF8.GetString(resultBytes.Array, 0, resultBytes.Count));
                         }
                         else
                         {
@@ -282,7 +282,7 @@ namespace Test.Client
         static void MessageReceived(object sender, MessageReceivedEventArgs args)
         {
             string msg = "(null)";
-            if (args.Data != null && args.Data.Length > 0) msg = Encoding.UTF8.GetString(args.Data);
+            if (args.Data != null && args.Data.Count > 0) msg = Encoding.UTF8.GetString(args.Data.Array, 0, args.Data.Count);
             Console.WriteLine(args.MessageType.ToString() + " from server: " + msg);
         }
          

--- a/src/Test.Echo/Program.cs
+++ b/src/Test.Echo/Program.cs
@@ -42,9 +42,9 @@ namespace Test.Echo
                 server.MessageReceived += async (s, e) =>
                 {
                     // echo it back
-                    serverStats.AddRecv(e.Data.Length);
+                    serverStats.AddRecv(e.Data.Count);
                     await server.SendAsync(e.IpPort, e.Data);
-                    serverStats.AddSent(e.Data.Length);
+                    serverStats.AddSent(e.Data.Count);
                 };
 
                 server.Logger = Logger;
@@ -131,7 +131,7 @@ namespace Test.Echo
 
                 client.MessageReceived += (s, e) =>
                 {
-                    clientStats.AddRecv(e.Data.Length);
+                    clientStats.AddRecv(e.Data.Count);
                 };
 
                 client.Logger = Logger;

--- a/src/Test.Integrity/Program.cs
+++ b/src/Test.Integrity/Program.cs
@@ -58,7 +58,7 @@ namespace Test.Integrity
 
                 server.MessageReceived += (s, e) =>
                 {
-                    serverStats.AddRecv(e.Data.Length);
+                    serverStats.AddRecv(e.Data.Count);
                 };
 
                 // server.Logger = Logger;
@@ -162,7 +162,7 @@ namespace Test.Integrity
 
                 client.MessageReceived += (s, e) =>
                 {
-                    stats.AddRecv(e.Data.Length);
+                    stats.AddRecv(e.Data.Count);
                 };
 
                 // client.Logger = Logger;

--- a/src/Test.Server/Program.cs
+++ b/src/Test.Server/Program.cs
@@ -309,7 +309,7 @@ namespace Test.Server
         static void MessageReceived(object sender, MessageReceivedEventArgs args)
         {
             string msg = "(null)";
-            if (args.Data != null && args.Data.Length > 0) msg = Encoding.UTF8.GetString(args.Data);
+            if (args.Data != null && args.Data.Count > 0) msg = Encoding.UTF8.GetString(args.Data.Array, 0, args.Data.Count);
             Console.WriteLine(args.MessageType.ToString() + " from " + args.IpPort + ": " + msg);
         }
 

--- a/src/WatsonWebsocket/MessageReceivedEventArgs.cs
+++ b/src/WatsonWebsocket/MessageReceivedEventArgs.cs
@@ -21,7 +21,7 @@ namespace WatsonWebsocket
         /// <summary>
         /// The data received.
         /// </summary>
-        public byte[] Data { get; } = null;
+        public ArraySegment<byte> Data { get; } = default;
 
         /// <summary>
         /// The type of payload included in the message (Binary or Text).
@@ -36,7 +36,7 @@ namespace WatsonWebsocket
 
         #region Constructors-and-Factories
 
-        internal MessageReceivedEventArgs(string ipPort, byte[] data, WebSocketMessageType messageType)
+        internal MessageReceivedEventArgs(string ipPort, ArraySegment<byte> data, WebSocketMessageType messageType)
         {
             IpPort = ipPort;
             Data = data;


### PR DESCRIPTION
For both Client and Server:

Changes:
- The internal receive buffer is now only allocated once 

Breaking Change:
- MessageReceivedEventArgs now returns an ArraySegment that directly refers to the internal MemoryStream, saving an extra allocation for each receive